### PR TITLE
Add additional styling and more details

### DIFF
--- a/src/Components/ArticleCard/ArticleCard.css
+++ b/src/Components/ArticleCard/ArticleCard.css
@@ -1,11 +1,17 @@
 .article-card {
   box-sizing: border-box;
-  border: 3px solid black;
-  padding: 10px;
+  border: 1px solid black;
+  padding: 20px;
+	padding-left: 40px;
 	border-radius: 10px;
+	background-color: #F6F5F3;
 }
 
-.home-byline,
+.home-byline {
+ color: black;
+ font-style: italic;
+}
+
 .home-pub-date {
 	color: black;
 }

--- a/src/Components/ArticleDetails/ArticleDetails.css
+++ b/src/Components/ArticleDetails/ArticleDetails.css
@@ -1,15 +1,49 @@
+.article-details-wrapper {
+	display: flex;
+	justify-content: center;
+	align-items: center;
+}
+
 .article-details-container {
 	text-align: center;
-	height: 100vh;
-	margin-top: 50px;
+	height: 70%;
+	width: 80%;
+	margin-top: 10px;
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	background-color: #F6F5F3;
+	border-radius: 10px;
 }
 
 .details-title {
 	padding: 0px;
-	margin: 0px;
+	margin-top: 30px;
+	margin-bottom: 0px;
+}
+
+.details-byline {
+	font-style: italic;
+}
+
+.details-back-button {
+	margin-top: 10px;
+	margin-bottom: 30px;
+	text-decoration: none;
 }
 
 .details-back-button:hover {
 	transform: scale(1.1);
 	cursor: pointer;
+}
+
+.details-image {
+	margin-top: 20px;
+	height: 300px;
+	width: 400px;
+	object-fit: cover;
+}
+
+.details-abstract {
+	width: 50%;
 }

--- a/src/Components/ArticleDetails/ArticleDetails.js
+++ b/src/Components/ArticleDetails/ArticleDetails.js
@@ -2,7 +2,7 @@ import React from 'react'
 import { Link } from 'react-router-dom'
 import './ArticleDetails.css'
 
-const ArticleDetails = ({ title, byline, abstract, published_date }) => {
+const ArticleDetails = ({ title, byline, abstract, published_date, multimedia, short_url }) => {
 
 	const newDate = (published_date) => {
 		return published_date.split('T')[0]
@@ -11,14 +11,18 @@ const ArticleDetails = ({ title, byline, abstract, published_date }) => {
 
 
 	return (
-		<div className="article-details-container">
-			<h2 className="details-title">{title}</h2>
-			<p className="details-byline">{byline}</p>
-			<p className="details-abstract">Description: {abstract}</p>
-			<p className="details-pub-date">Published: {newDate(published_date)}</p>
-			<Link to="/">
-				<button className="details-back-button">Back to Main</button>
-			</Link>
+		<div className="article-details-wrapper">
+			<div className="article-details-container">
+				<h2 className="details-title">{title}</h2>
+				<p className="details-byline">{byline}</p>
+				<img className="details-image"src={multimedia[0].url} alt="article-image"/>
+				<p className="details-abstract">Description: <br></br> {abstract}</p>
+				<p className="details-pub-date">Published: {newDate(published_date)}</p>
+				<a href={short_url} className="nyt-button" target="_blank" rel="noopener noreferrer">See Article on New York Times</a>
+				<Link to="/">
+					<button className="details-back-button">Back to Main</button>
+				</Link>
+			</div>
 		</div>
 	)
 }


### PR DESCRIPTION
## Summary:
- Add image and nyt article links to ArticleDetails page. 
- Update styling on home page and article details page

## Type of Changes:
- [ ] Bug fix
- [x] Refactor
- [x] New feature


## How was this tested:
Chrome

## What are the relevant tickets:
Closes #11  #12 